### PR TITLE
Limit 32bit test to Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "cython; python_version >= '3.7' and 'free-threading' in sys_abi_features",
-    "numpy; '32-bit' in sys_abi_features",
+    "numpy; platform_system == 'Windows' and '32-bit' in sys_abi_features",
     "scipy; '64-bit' in sys_abi_features",
 #    "pip",
 ]


### PR DESCRIPTION
This limits the test for 32-bit to the windows platform, where it can actually occur.